### PR TITLE
Add possibility to configure NIC and CIDR used for tunnel networks

### DIFF
--- a/api/bases/ovs.openstack.org_ovs.yaml
+++ b/api/bases/ovs.openstack.org_ovs.yaml
@@ -93,6 +93,10 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              tunnelNetworkCidr:
+                type: string
+              tunnelNetworkNic:
+                type: string
             required:
             - ovnContainerImage
             - ovsContainerImage
@@ -157,6 +161,9 @@ spec:
                 description: NumberReady of the ovs instances
                 format: int32
                 type: integer
+              tunnelNetworkIP:
+                description: IP address used to establish tunnels
+                type: string
             type: object
         type: object
     served: true

--- a/api/v1beta1/ovs_types.go
+++ b/api/v1beta1/ovs_types.go
@@ -35,6 +35,14 @@ type OVSSpec struct {
 	OvnContainerImage string `json:"ovnContainerImage"`
 
 	// +kubebuilder:validation:Optional
+	// +optional
+	TunnelNetworkNic string `json:"tunnelNetworkNic,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +optional
+	TunnelNetworkCidr string `json:"tunnelNetworkCidr,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	NicMappings map[string]string `json:"nic_mappings,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -60,6 +68,9 @@ type OVSStatus struct {
 
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
+
+	// IP address used to establish tunnels
+	TunnelNetworkIP string `json:"tunnelNetworkIP,omitempty" optional:"PodIP"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/ovs.openstack.org_ovs.yaml
+++ b/config/crd/bases/ovs.openstack.org_ovs.yaml
@@ -93,6 +93,10 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              tunnelNetworkCidr:
+                type: string
+              tunnelNetworkNic:
+                type: string
             required:
             - ovnContainerImage
             - ovsContainerImage
@@ -157,6 +161,9 @@ spec:
                 description: NumberReady of the ovs instances
                 format: int32
                 type: integer
+              tunnelNetworkIP:
+                description: IP address used to establish tunnels
+                type: string
             type: object
         type: object
     served: true

--- a/config/samples/ovs_v1beta1_ovs.yaml
+++ b/config/samples/ovs_v1beta1_ovs.yaml
@@ -10,5 +10,7 @@ spec:
     ovn-bridge: "br-int"
     ovn-encap-type: "geneve,vxlan"
   nic_mappings:
-    physnet1: enp2s0.100
-    physnet2: enp2s0.200
+    physnet2: enp2s0.100
+    physnet3: enp2s0.200
+  tunnelNetworkCidr: 10.20.30.40/24
+  tunnelNetworkNic: enp2s0.300

--- a/controllers/ovs_controller.go
+++ b/controllers/ovs_controller.go
@@ -299,6 +299,16 @@ func (r *OVSReconciler) reconcileNormal(ctx context.Context, instance *ovsv1beta
 		5,
 	)
 
+	if instance.Spec.TunnelNetworkCidr != "" {
+		tunnelIP, err := ovs.GetIPFromCidr(instance.Spec.TunnelNetworkCidr)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		instance.Status.TunnelNetworkIP = tunnelIP
+	} else {
+		instance.Status.TunnelNetworkIP = "Check POD IP address"
+	}
+
 	ctrlResult, err = dset.CreateOrPatch(ctx, helper)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/pkg/ovs/const.go
+++ b/pkg/ovs/const.go
@@ -11,4 +11,6 @@ const (
 	ServiceAccountName = "ovs-operator-ovs"
 	// KollaConfigAPI -
 	KollaConfigAPI = "/var/lib/config-data/merged/ovs-config.json"
+	//TunnelNetworkName -
+	TunnelNetworkName = "tunnel-network"
 )

--- a/pkg/ovs/daemonset.go
+++ b/pkg/ovs/daemonset.go
@@ -78,9 +78,17 @@ func DaemonSet(
 	envVars["OvnBridge"] = env.SetValue(instance.Spec.ExternalIDS.OvnBridge)
 	envVars["OvnRemote"] = env.SetValue(dbmap["SB"])
 	envVars["OvnEncapType"] = env.SetValue(instance.Spec.ExternalIDS.OvnEncapType)
-	envVars["OvnEncapIP"] = EnvDownwardAPI("status.podIP")
 	envVars["EnableChassisAsGateway"] = env.SetValue(fmt.Sprintf("%t", instance.Spec.ExternalIDS.EnableChassisAsGateway))
+	envVars["PodIP"] = EnvDownwardAPI("status.podIP")
 	envVars["PhysicalNetworks"] = env.SetValue(getPhysicalNetworks(instance))
+	if instance.Spec.TunnelNetworkCidr != "" {
+		envVars["TunnelNetworkCidr"] = env.SetValue(instance.Spec.TunnelNetworkCidr)
+		tunnelIP, err := GetIPFromCidr(instance.Spec.TunnelNetworkCidr)
+		if err != nil {
+			return nil, err
+		}
+		envVars["OvnEncapIP"] = env.SetValue(tunnelIP)
+	}
 
 	networkList, err := getNetworksList(instance)
 	if err != nil {


### PR DESCRIPTION
To establish Geneve or Vxlan tunnels there is need to have L3 connectivity with other members of the cluster. This patch adds 2 new options in the openvswitch API: "tunnelNetworkNic" and "tunnelNetworkCidr" to allow configuring dedicated network for such tunnels connectivity.
By default, if those options aren't set, PodIP address will be used as tunnel endpoint in the OVS POD.