### PR TITLE
Set nodeName as hostname in ovsdb

### DIFF
--- a/pkg/ovs/daemonset.go
+++ b/pkg/ovs/daemonset.go
@@ -81,6 +81,7 @@ func DaemonSet(
 	envVars["OvnEncapIP"] = EnvDownwardAPI("status.podIP")
 	envVars["EnableChassisAsGateway"] = env.SetValue(fmt.Sprintf("%t", instance.Spec.ExternalIDS.EnableChassisAsGateway))
 	envVars["PhysicalNetworks"] = env.SetValue(getPhysicalNetworks(instance))
+	envVars["OvnHostName"] = EnvDownwardAPI("spec.nodeName")
 
 	networkList, err := getNetworksList(instance)
 	if err != nil {

--- a/templates/bin/init.sh
+++ b/templates/bin/init.sh
@@ -22,6 +22,7 @@ OvnEncapType=${OvnEncapType:-"geneve"}
 OvnEncapIP=${OvnEncapIP:-"127.0.0.1"}
 EnableChassisAsGateway=${EnableChassisAsGateway:-false}
 PhysicalNetworks=${PhysicalNetworks:-""}
+OvnHostName=${OvnHostName:-""}
 
 function wait_for_ovsdb_server {
     while true; do
@@ -41,6 +42,9 @@ function configure_external_ids {
     ovs-vsctl set open . external-ids:ovn-remote=${OvnRemote}
     ovs-vsctl set open . external-ids:ovn-encap-type=${OvnEncapType}
     ovs-vsctl set open . external-ids:ovn-encap-ip=${OvnEncapIP}
+    if [ -n "$OvnHostName" ]; then
+        ovs-vsctl set open . external-ids:hostname=${OvnHostName}
+    fi
     if [ "$EnableChassisAsGateway" == "true" ]; then
         ovs-vsctl set open . external-ids:ovn-cms-options=enable-chassis-as-gw
     fi


### PR DESCRIPTION
Hostname in ovsdb is used by ovn-controller to identify chassis and should be consistent for all time when POD is running on given node (ovsdb is stick to the node always) so we can configure "external-ids:hostname" in ovsdb as nodeName and that way it will always be the same on the same node and will be easier to identify in e.g. Neutron API where ovn-controller (neutron agent) really is running.