### PR TITLE
use stable zed container image for ovn

### DIFF
--- a/api/bases/ovs.openstack.org_ovs.yaml
+++ b/api/bases/ovs.openstack.org_ovs.yaml
@@ -63,9 +63,11 @@ spec:
                   this service
                 type: object
               ovnContainerImage:
+                default: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
                 description: Image used for the ovn-controller container
                 type: string
               ovsContainerImage:
+                default: quay.io/skaplons/ovs:latest
                 description: Image used for the ovsdb-server and ovs-vswitchd containers
                 type: string
               resources:
@@ -95,9 +97,6 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-            required:
-            - ovnContainerImage
-            - ovsContainerImage
             type: object
           status:
             description: OVSStatus defines the observed state of OVS

--- a/api/v1beta1/ovs_types.go
+++ b/api/v1beta1/ovs_types.go
@@ -28,9 +28,13 @@ type OVSSpec struct {
 	// +kubebuilder:validation:Optional
 	ExternalIDS OVSExternalIDs `json:"external-ids"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="quay.io/skaplons/ovs:latest"
 	// Image used for the ovsdb-server and ovs-vswitchd containers
 	OvsContainerImage string `json:"ovsContainerImage"`
 
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
 	// Image used for the ovn-controller container
 	OvnContainerImage string `json:"ovnContainerImage"`
 

--- a/config/crd/bases/ovs.openstack.org_ovs.yaml
+++ b/config/crd/bases/ovs.openstack.org_ovs.yaml
@@ -63,9 +63,11 @@ spec:
                   this service
                 type: object
               ovnContainerImage:
+                default: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
                 description: Image used for the ovn-controller container
                 type: string
               ovsContainerImage:
+                default: quay.io/skaplons/ovs:latest
                 description: Image used for the ovsdb-server and ovs-vswitchd containers
                 type: string
               resources:
@@ -95,9 +97,6 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
-            required:
-            - ovnContainerImage
-            - ovsContainerImage
             type: object
           status:
             description: OVSStatus defines the observed state of OVS

--- a/config/samples/ovs_v1beta1_ovs.yaml
+++ b/config/samples/ovs_v1beta1_ovs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openvswitch
 spec:
   ovsContainerImage: "quay.io/skaplons/ovs:latest"
-  ovnContainerImage: "quay.io/tripleowallaby/openstack-ovn-controller:current-tripleo"
+  ovnContainerImage: "quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
   external-ids:
     system-id: "random"
     ovn-bridge: "br-int"


### PR DESCRIPTION
This change makes the container image optional and defaults
the ovn container to use the stable/zed image.

The ovs image is also default to the existing image.
