### PR TITLE
Logging: Use ISO8601 timestamps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
+	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/exp v0.0.0-20221031165847-c99f073a8326
 	golang.org/x/net v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -293,12 +293,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
 github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221103175706-2c39582ce513 h1:PSXOLFTskoG9R/YR4Pg5AOJYS3CEnFbZ2yVdrk9xOE4=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221103175706-2c39582ce513/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221124114404-c42a739be111 h1:X5Y2zXwOiPPFoQN0Ox8C2jL1tZo3+S9BjcOf9h/EYbU=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221124114404-c42a739be111/go.mod h1:qV9OlokZRpqbHI3lmeN5EOmIKynWphw6GPl3zP9KOGM=
-github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221104055612-c6a1c9f90b72 h1:C5n6qi8FNyh0QXmXpiwZb+9d4ciPvsgVIKiQY09lZBA=
-github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221104055612-c6a1c9f90b72/go.mod h1:2hgx7ZLkqxlo10t7OLgD7R4jMMggHiLdXaidTmQbJNY=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221202132252-c8c01499b7aa h1:VKypRbdA2xyRUw7zUpZetibE72sdUJPozxs4+6d0DuQ=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221202132252-c8c01499b7aa/go.mod h1:w9jM6WK5YUPSHgChU/mYjlf83ae+ZP7GGI888ToureE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -64,6 +65,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
The default value for the zap logger is using epoch timestamps, but that's not user friendly, so we are changing it to using the ISO8601 time format instead.

The zap package from uber is already a dependency from the zap module of the controller-runtime package we already use, so we are not adding any new dependency.

Signed-off-by: Yatin Karel <ykarel@redhat.com>