### PR TITLE
Set geneve as default for ovn-encap-type

### DIFF
--- a/api/bases/ovs.openstack.org_ovs.yaml
+++ b/api/bases/ovs.openstack.org_ovs.yaml
@@ -44,12 +44,16 @@ spec:
                   ovn-bridge:
                     type: string
                   ovn-encap-type:
+                    default: geneve
+                    description: OvnEncapType - geneve or vxlan
+                    enum:
+                    - geneve
+                    - vxlan
                     type: string
                   system-id:
                     type: string
                 required:
                 - ovn-bridge
-                - ovn-encap-type
                 - system-id
                 type: object
               nic_mappings:

--- a/api/v1beta1/ovs_types.go
+++ b/api/v1beta1/ovs_types.go
@@ -103,6 +103,12 @@ func (instance OVS) IsReady() bool {
 type OVSExternalIDs struct {
 	SystemID               string `json:"system-id"`
 	OvnBridge              string `json:"ovn-bridge"`
-	OvnEncapType           string `json:"ovn-encap-type"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="geneve"
+	// +kubebuilder:validation:Enum={"geneve","vxlan"}
+	// OvnEncapType - geneve or vxlan
+	OvnEncapType           string `json:"ovn-encap-type,omitempty"`
+
 	EnableChassisAsGateway bool   `json:"enable-chassis-as-gateway,omitempty" optional:"true"`
 }

--- a/config/crd/bases/ovs.openstack.org_ovs.yaml
+++ b/config/crd/bases/ovs.openstack.org_ovs.yaml
@@ -44,12 +44,16 @@ spec:
                   ovn-bridge:
                     type: string
                   ovn-encap-type:
+                    default: geneve
+                    description: OvnEncapType - geneve or vxlan
+                    enum:
+                    - geneve
+                    - vxlan
                     type: string
                   system-id:
                     type: string
                 required:
                 - ovn-bridge
-                - ovn-encap-type
                 - system-id
                 type: object
               nic_mappings:

--- a/config/samples/ovs_v1beta1_ovs.yaml
+++ b/config/samples/ovs_v1beta1_ovs.yaml
@@ -8,7 +8,7 @@ spec:
   external-ids:
     system-id: "random"
     ovn-bridge: "br-int"
-    ovn-encap-type: "geneve,vxlan"
+    ovn-encap-type: "geneve"
   nic_mappings:
     physnet1: enp2s0.100
     physnet2: enp2s0.200


### PR DESCRIPTION
Setting vxlan in ovn-encap-type imposes limitation on total number of networks and ports to be created to 4096 which is not ideal for default settings.

Also add validation for it to be either "geneve" or "vxlan".

Signed-off-by: Yatin Karel <ykarel@redhat.com>