### PR TITLE
Change name of the NIC mappings API option

### DIFF
--- a/api/bases/ovs.openstack.org_ovs.yaml
+++ b/api/bases/ovs.openstack.org_ovs.yaml
@@ -56,7 +56,7 @@ spec:
                 - ovn-bridge
                 - system-id
                 type: object
-              nic_mappings:
+              nicMappings:
                 additionalProperties:
                   type: string
                 type: object

--- a/api/v1beta1/ovs_types.go
+++ b/api/v1beta1/ovs_types.go
@@ -40,7 +40,7 @@ type OVSSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +optional
-	NicMappings map[string]string `json:"nic_mappings,omitempty"`
+	NicMappings map[string]string `json:"nicMappings,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).

--- a/config/crd/bases/ovs.openstack.org_ovs.yaml
+++ b/config/crd/bases/ovs.openstack.org_ovs.yaml
@@ -56,7 +56,7 @@ spec:
                 - ovn-bridge
                 - system-id
                 type: object
-              nic_mappings:
+              nicMappings:
                 additionalProperties:
                   type: string
                 type: object

--- a/config/samples/ovs_v1beta1_ovs.yaml
+++ b/config/samples/ovs_v1beta1_ovs.yaml
@@ -9,6 +9,6 @@ spec:
     system-id: "random"
     ovn-bridge: "br-int"
     ovn-encap-type: "geneve"
-  nic_mappings:
+  nicMappings:
     physnet1: enp2s0.100
     physnet2: enp2s0.200


### PR DESCRIPTION
It was previously named "nic_mappings" but to be more consistent with other options in the OVS Spec it is now changed to "nicMappings". We are still in the very early stage of the ovs operator and its API so it should be safe to change that name now.