### PR TITLE
Gracefully terminate containers on pod delete

### DIFF
--- a/pkg/ovs/daemonset.go
+++ b/pkg/ovs/daemonset.go
@@ -158,7 +158,16 @@ func DaemonSet(
 							},
 							Args: []string{
 								// First configure external ids and then start ovn controller
-								"/usr/local/bin/container-scripts/init.sh && /usr/bin/ovn-controller --pidfile --log-file unix:/run/openvswitch/db.sock",
+								"/usr/local/bin/container-scripts/init.sh && ovn-controller --pidfile unix:/run/openvswitch/db.sock",
+							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.LifecycleHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/usr/share/ovn/scripts/ovn-ctl", "stop_controller",
+										},
+									},
+								},
 							},
 							Image: instance.Spec.OvnContainerImage,
 							// TODO(slaweq): to check if ovn-controller really needs such security contexts

--- a/pkg/ovs/daemonset.go
+++ b/pkg/ovs/daemonset.go
@@ -113,6 +113,15 @@ func DaemonSet(
 							Command: []string{
 								"/usr/local/bin/container-scripts/start-ovsdb-server.sh",
 							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.LifecycleHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/usr/share/openvswitch/scripts/ovs-ctl", "stop", "--no-ovs-vswitchd",
+										},
+									},
+								},
+							},
 							Image: instance.Spec.OvsContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{

--- a/pkg/ovs/daemonset.go
+++ b/pkg/ovs/daemonset.go
@@ -136,6 +136,15 @@ func DaemonSet(
 							Args: []string{
 								"--pidfile", "--mlockall",
 							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.LifecycleHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{
+											"/usr/share/openvswitch/scripts/ovs-ctl", "stop", "--no-ovsdb-server",
+										},
+									},
+								},
+							},
 							Image: instance.Spec.OvsContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{

--- a/templates/bin/start-ovsdb-server.sh
+++ b/templates/bin/start-ovsdb-server.sh
@@ -17,15 +17,9 @@ set -ex
 
 CTL_ARGS="--system-id=random --no-ovs-vswitchd"
 
-function run() {
-    /usr/share/openvswitch/scripts/ovs-ctl $@ $CTL_ARGS
-}
-
 # Initialize or upgrade database if needed
-run start
-run stop
-
-trap 'run stop' SIGTERM
+/usr/share/openvswitch/scripts/ovs-ctl start $CTL_ARGS
+/usr/share/openvswitch/scripts/ovs-ctl stop $CTL_ARGS
 
 # Start the service
 ovsdb-server /etc/openvswitch/conf.db \
@@ -33,6 +27,4 @@ ovsdb-server /etc/openvswitch/conf.db \
     --remote=punix:/var/run/openvswitch/db.sock \
     --private-key=db:Open_vSwitch,SSL,private_key \
     --certificate=db:Open_vSwitch,SSL,certificate \
-    --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert &
-
-wait
+    --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert


### PR DESCRIPTION
Use PreStop hooks for all containers of the ovs pod.