### PR TITLE
Fix wait_for_ovsdb_server routine for ovn-controller container

### DIFF
--- a/templates/bin/init.sh
+++ b/templates/bin/init.sh
@@ -13,7 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-set -ex
+set -x
 
 # Configs are obtained from ENV variables.
 OvnBridge=${OvnBridge:-"br-int"}


### PR DESCRIPTION
It was bailing out of the init.sh script on the first ovs-vsctl show failure that was supposed to be a wait-function, not a fail-function. This is because `set -e` makes the script fail if any command executed return !=0.

Signed-off-by: Ihar Hrachyshka <ihrachys@redhat.com>