### PR TITLE
 Add basic KUTTL tests for ovs operator

### DIFF
--- a/config/samples/ovs_v1beta1_ovs.yaml
+++ b/config/samples/ovs_v1beta1_ovs.yaml
@@ -9,6 +9,3 @@ spec:
     system-id: "random"
     ovn-bridge: "br-int"
     ovn-encap-type: "geneve"
-  nicMappings:
-    physnet1: enp2s0.100
-    physnet2: enp2s0.200

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,25 @@
+#
+# EXECUTION (from install_yamls repo root):
+#
+#   make ovs_kuttl
+#
+# ASSUMPTIONS:
+#
+# 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - chmod 755 /usr/local/bin/kubectl-kuttl
+# 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
+# 3. CLI user has access to $KUBECONFIG
+# 4. The environment variable INSTALL_YAMLS is set to the the path of the
+#    install_yamls repo
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-test-ovs
+namespace: openstack
+timeout: 180
+parallel: 1
+suppress:
+  - events                     # Remove spammy event logs

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -1,0 +1,292 @@
+#
+# Check for:
+#
+# - 1 OVS CR
+# - Daemonset with 3 Pods for OVS CR
+
+apiVersion: ovs.openstack.org/v1beta1
+kind: OVS
+metadata:
+  finalizers:
+  - OVS
+  name: openvswitch
+  namespace: openstack
+spec:
+  external-ids:
+    ovn-bridge: br-int
+    ovn-encap-type: geneve
+    system-id: random
+  ovnContainerImage: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+  ovsContainerImage: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+status:
+  desiredNumberScheduled: 1
+  numberReady: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ovs
+  namespace: openstack
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      service: ovs
+  template:
+    metadata:
+      labels:
+        service: ovs
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/container-scripts/start-ovsdb-server.sh
+        image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/share/openvswitch/scripts/ovs-ctl
+              - stop
+              - --no-ovs-vswitchd
+        livenessProbe:
+          exec:
+            command:
+            - /usr/bin/ovs-vsctl
+            - show
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: ovsdb-server
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - --pidfile
+        - --mlockall
+        command:
+        - /usr/sbin/ovs-vswitchd
+        image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/share/openvswitch/scripts/ovs-ctl
+              - stop
+              - --no-ovsdb-server
+        livenessProbe:
+          exec:
+            command:
+            - /usr/bin/ovs-appctl
+            - bond/show
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 3
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: ovs-vswitchd
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - /usr/local/bin/container-scripts/init.sh && ovn-controller --pidfile unix:/run/openvswitch/db.sock
+        command:
+        - /bin/bash
+        - -c
+        image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/share/ovn/scripts/ovn-ctl
+              - stop_controller
+        name: ovn-controller
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - SYS_NICE
+          privileged: true
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: ovs-operator-ovs
+      serviceAccountName: ovs-operator-ovs
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 1
+  updatedNumberScheduled: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  generateName: ovs-
+  labels:
+    service: ovs
+  namespace: openstack
+spec:
+  containers:
+  - command:
+    - /usr/local/bin/container-scripts/start-ovsdb-server.sh
+    image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+    imagePullPolicy: IfNotPresent
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - /usr/share/openvswitch/scripts/ovs-ctl
+          - stop
+          - --no-ovs-vswitchd
+    livenessProbe:
+      exec:
+        command:
+        - /usr/bin/ovs-vsctl
+        - show
+      failureThreshold: 3
+      initialDelaySeconds: 3
+      periodSeconds: 3
+      successThreshold: 1
+      timeoutSeconds: 5
+    name: ovsdb-server
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_NICE
+      privileged: true
+      runAsUser: 0
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: FallbackToLogsOnError
+  - args:
+    - --pidfile
+    - --mlockall
+    command:
+    - /usr/sbin/ovs-vswitchd
+    image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+    imagePullPolicy: IfNotPresent
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - /usr/share/openvswitch/scripts/ovs-ctl
+          - stop
+          - --no-ovsdb-server
+    livenessProbe:
+      exec:
+        command:
+        - /usr/bin/ovs-appctl
+        - bond/show
+      failureThreshold: 3
+      initialDelaySeconds: 3
+      periodSeconds: 3
+      successThreshold: 1
+      timeoutSeconds: 5
+    name: ovs-vswitchd
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_NICE
+      privileged: true
+      runAsUser: 0
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: FallbackToLogsOnError
+  - args:
+    - /usr/local/bin/container-scripts/init.sh && ovn-controller --pidfile unix:/run/openvswitch/db.sock
+    command:
+    - /bin/bash
+    - -c
+    image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+    imagePullPolicy: IfNotPresent
+    lifecycle:
+      preStop:
+        exec:
+          command:
+          - /usr/share/ovn/scripts/ovn-ctl
+          - stop_controller
+    name: ovn-controller
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - SYS_ADMIN
+        - SYS_NICE
+      privileged: true
+      runAsUser: 0
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: FallbackToLogsOnError
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: ovs-operator-ovs
+  serviceAccountName: ovs-operator-ovs
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/disk-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/memory-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/pid-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/unschedulable
+    operator: Exists
+status:
+  phase: Running
+  qosClass: BestEffort

--- a/tests/kuttl/common/cleanup-ovs.yaml
+++ b/tests/kuttl/common/cleanup-ovs.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS ovs_deploy_cleanup

--- a/tests/kuttl/common/deploy_ovs.yaml
+++ b/tests/kuttl/common/deploy_ovs.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS ovs_deploy

--- a/tests/kuttl/common/errors_cleanup_ovs.yaml
+++ b/tests/kuttl/common/errors_cleanup_ovs.yaml
@@ -1,0 +1,29 @@
+#
+# Check for:
+#
+# No OVS CR
+# No DaemonSet CR
+ 
+apiVersion: ovs.openstack.org/v1beta1
+kind: OVS
+metadata:
+  finalizers:
+  - OVS
+  name: openvswitch
+  namespace: openstack
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ovs
+  namespace: openstack
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  generateName: ovs-
+  labels:
+    service: ovs
+  namespace: openstack

--- a/tests/kuttl/tests/ovs_deploy/01-assert.yaml
+++ b/tests/kuttl/tests/ovs_deploy/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/tests/kuttl/tests/ovs_deploy/01-deploy-ovs.yaml
+++ b/tests/kuttl/tests/ovs_deploy/01-deploy-ovs.yaml
@@ -1,0 +1,1 @@
+../../common/deploy_ovs.yaml

--- a/tests/kuttl/tests/ovs_deploy/02-errors.yaml
+++ b/tests/kuttl/tests/ovs_deploy/02-errors.yaml
@@ -1,0 +1,11 @@
+#
+# Check for:
+#
+# No OVS pods after asking for a non existing node in nodeSelector
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ovs
+  namespace: openstack

--- a/tests/kuttl/tests/ovs_deploy/02-scale-down-pods-ovs.yaml
+++ b/tests/kuttl/tests/ovs_deploy/02-scale-down-pods-ovs.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch OVS -n openstack openvswitch --type='json' -p='[{"op": "replace", "path": "/spec/nodeSelector", "value":{"node": "non-existing-node-name"}}]'

--- a/tests/kuttl/tests/ovs_deploy/03-cleanup-ovs.yaml
+++ b/tests/kuttl/tests/ovs_deploy/03-cleanup-ovs.yaml
@@ -1,0 +1,1 @@
+../../common/cleanup-ovs.yaml

--- a/tests/kuttl/tests/ovs_deploy/03-errors.yaml
+++ b/tests/kuttl/tests/ovs_deploy/03-errors.yaml
@@ -1,0 +1,1 @@
+../../common/errors_cleanup_ovs.yaml


### PR DESCRIPTION
These tests cover basic operations: deployment and clean up.  I've not included other common operations like scaling up and down because the ovs operator deploys a `Daemonset` and those operations do not apply. But I can include them if I missed something.

The tests use code from the install_yamls repo to reuse some operations like the deployment of the ovs operators, as well as the cleanup from previous runs.

Test are thought to be run from the `install_yamls` repo, see the following
PR: https://github.com/openstack-k8s-operators/install_yamls/pull/97

There are three ways to run the tests:
1) Run `make ovs_kuttl`, this will only work if you want to run the test
from the master branch.
2) Run `make ovs_kuttl OVS_REPO=ovs-operator._repo_url
OVS_BRANCH=branch_name` this is useful if you want to run the tests from
a fork
3) Run `make ovs_kuttl
OVS_KUTTL_CONF=/path/to/ovs-operator/kuttl-test.yaml
OVS_KUTTL_DIR=/path/to/ovs-operator/tests/kuttl/tests/` this is
useful to run local changes to the tests
