### PR TITLE
Add revive to golanci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errorlint
+    - revive
+    - gofmt
+    - govet
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,7 @@ repos:
 - repo: https://github.com/dnephin/pre-commit-golang
   rev: v0.5.1
   hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
     - id: go-mod-tidy
-    - id: go-lint
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
@@ -51,3 +47,9 @@ repos:
     - id: no-commit-to-branch
     - id: trailing-whitespace
       exclude: ^vendor
+
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.52.2
+  hooks:
+    - id: golangci-lint
+      args: ["-v"]

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,12 @@ golangci: get-ci-tools
 golint: get-ci-tools
 	PATH=$(GOBIN):$(PATH); $(CI_TOOLS_REPO_DIR)/test-runner/golint.sh
 
+# Run go mod tidy against code
+.PHONY: tidy
+tidy: ## Run go mod tidy on every mod file in the repo
+	go mod tidy
+	cd ./api && go mod tidy
+
 .PHONY: gowork
 gowork: ## Generate go.work file to support our multi module repository
 	test -f go.work || go work init

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,6 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230220105454-15b
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230220105454-15b5585e4e29/go.mod h1:5kG0Ct412tO3fNkZ5b3/BwwSsV7LkSNfOB/apUlbMJI=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230309154649-7d7c02030c78 h1:pXapWJYRuxVMjVsaLkBOUl31Xauyhf+jzGxmaMH6eAM=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230309154649-7d7c02030c78/go.mod h1:wDUzrnAhtC0O99PYR8qQWQoGJzVQwGnfGepKzExCVk8=
-github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221083334-f77d76772a0e h1:G5s0MasnPwIOogyPK5Ce4F+2mxvD/+sJQUaC20BDeJk=
-github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20221221083334-f77d76772a0e/go.mod h1:GUQ966Lr4rg+XnIYlYO+YX+rMg7OmNzYYvDk4uSIQVU=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230324110832-22157b6770f3 h1:7cy1GXiMG1BBkxaj+3nGIwcGDOTcMrEi+8IJ9aHe1b4=
 github.com/openstack-k8s-operators/ovn-operator/api v0.0.0-20230324110832-22157b6770f3/go.mod h1:vsHUVpBJYuphy753SLEKvNKX2FgtauSrxsxM3CeuDkM=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/kuttl/common/errors_cleanup_ovs.yaml
+++ b/tests/kuttl/common/errors_cleanup_ovs.yaml
@@ -3,7 +3,7 @@
 #
 # No OVS CR
 # No DaemonSet CR
- 
+
 apiVersion: ovs.openstack.org/v1beta1
 kind: OVS
 metadata:


### PR DESCRIPTION
This PR replace deprecated go-linter using
revive (https://golangci-lint.run/usage/linters/#revive).

We will add "ginkgolinter" in follow up patch once we merged add pre-commit job in openshift/releases.

If we add "ginkgolinter" in this patch then it's causes below issue [1]

```
level=info msg="[config_reader] Config search paths: [./ /home/prow/go/src/github.com/openstack-k8s-operators/dataplane-operator /home/prow/go/src/github.com/openstack-k8s-operators /home/prow/go/src/github.com /home/prow/go/src /home/prow/go /home/prow /home /]"
level=info msg="[config_reader] Used config file .golangci.yaml"
level=error msg="Running error: unknown linters: 'ginkgolinter', run 'golangci-lint help linters' to see the list of supported linters"
```

This patch also Remove fmt dependency from make tidy as per [2]:

The fmt dependency cannot be run if the go.mod file needs an update:
```
 $ make tidy
 go fmt ./...
 go: updates to go.mod needed; to update it:
        go mod tidy
 make: *** [Makefile:103: fmt] Error 1
```

I have also made some changes as per the comment given here [3]

[1]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openstack-k8s-operators_dataplane-operator/147/pull-ci-openstack-k8s-operators-dataplane-operator-main-golangci/1643555465537261568/artifacts/test/build-log.txt 
[2]: https://github.com/openstack-k8s-operators/placement-operator/pull/153
[3]: https://github.com/openstack-k8s-operators/cinder-operator/pull/147#discussion_r1158504341