### PR TITLE
Remove omitempty in favor of kubebuilder:default

### DIFF
--- a/api/v1beta1/ovs_types.go
+++ b/api/v1beta1/ovs_types.go
@@ -116,7 +116,7 @@ type OVSExternalIDs struct {
 	// +kubebuilder:default="geneve"
 	// +kubebuilder:validation:Enum={"geneve","vxlan"}
 	// OvnEncapType - geneve or vxlan
-	OvnEncapType string `json:"ovn-encap-type,omitempty"`
+	OvnEncapType string `json:"ovn-encap-type"`
 
 	EnableChassisAsGateway bool `json:"enable-chassis-as-gateway,omitempty" optional:"true"`
 }


### PR DESCRIPTION
This patch fixes an operator-lint issue:
$ api/v1beta1/ovs_types.go:119:2: C003: Field 'OvnEncapType' has both a 'Optional'
  kubebuilder marker with a default value and an 'omitempty' tag. Either remove the
  default value or remove 'omitempty'