### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,8 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/movs.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export OVS_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
-run-with-webhook: export OVN_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+run-with-webhook: export OVS_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
+run-with-webhook: export OVN_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,6 +12,6 @@ spec:
       - name: manager
         env:
         - name: OVS_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
         - name: OVN_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified

--- a/config/samples/ovs_v1beta1_ovs.yaml
+++ b/config/samples/ovs_v1beta1_ovs.yaml
@@ -3,8 +3,8 @@ kind: OVS
 metadata:
   name: openvswitch
 spec:
-  ovsContainerImage: "quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo"
-  ovnContainerImage: "quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo"
+  ovsContainerImage: "quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified"
+  ovnContainerImage: "quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified"
   external-ids:
     system-id: "random"
     ovn-bridge: "br-int"

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -16,8 +16,8 @@ spec:
     ovn-bridge: br-int
     ovn-encap-type: geneve
     system-id: random
-  ovnContainerImage: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
-  ovsContainerImage: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+  ovnContainerImage: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+  ovsContainerImage: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
 status:
   desiredNumberScheduled: 1
   numberReady: 1
@@ -40,7 +40,7 @@ spec:
       containers:
       - command:
         - /usr/local/bin/container-scripts/start-ovsdb-server.sh
-        image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -76,7 +76,7 @@ spec:
         - --mlockall
         command:
         - /usr/sbin/ovs-vswitchd
-        image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -112,7 +112,7 @@ spec:
         command:
         - /bin/bash
         - -c
-        image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -166,7 +166,7 @@ spec:
   containers:
   - command:
     - /usr/local/bin/container-scripts/start-ovsdb-server.sh
-    image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+    image: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
     imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:
@@ -202,7 +202,7 @@ spec:
     - --mlockall
     command:
     - /usr/sbin/ovs-vswitchd
-    image: quay.io/tripleozedcentos9/openstack-ovn-base:current-tripleo
+    image: quay.io/podified-antelope-centos9/openstack-ovn-base:current-podified
     imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:
@@ -238,7 +238,7 @@ spec:
     command:
     - /bin/bash
     - -c
-    image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+    image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
     imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib