### PR TITLE
Remove install_yamls dependency for kuttl tests

### DIFF
--- a/tests/kuttl/common/cleanup-ovs.yaml
+++ b/tests/kuttl/common/cleanup-ovs.yaml
@@ -1,6 +1,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-commands:
-  - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS ovs_deploy_cleanup
+delete:
+- apiVersion: ovs.openstack.org/v1beta1
+  kind: OVS
+  name: openvswitch
+  namespace: openstack

--- a/tests/kuttl/common/deploy_ovs.yaml
+++ b/tests/kuttl/common/deploy_ovs.yaml
@@ -2,5 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS ovs_deploy
+      oc apply -n openstack -f ../../../../config/samples/ovs_v1beta1_ovs.yaml


### PR DESCRIPTION
Instead of using install_yamls targets for deploying and cleaning up ironic, use the CR sample from config/samples. This removes a possible circular dependency issue when using install_yamls to run the jobs and to run some test steps.