### PR TITLE
Fix cp -a permission issue in make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
-	rm -f api/bases/* && cp -a config/crd/bases api/
+	rm -rf api/bases && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
Similar to [1], noticed in [2].

[1] https://github.com/openstack-k8s-operators/neutron-operator/commit/17dedeeb
[2] https://github.com/openshift/release/pull/39105