### PR TITLE
Reset Ready condition when update failed

### DIFF
--- a/api/v1beta1/ovs_types.go
+++ b/api/v1beta1/ovs_types.go
@@ -114,8 +114,8 @@ func init() {
 // IsReady - returns true if service is ready to server requests
 func (instance OVS) IsReady() bool {
 	// Ready when:
-	// there is at least a single pod to running OVS and ovn-controller
-	return instance.Status.NumberReady == instance.Status.DesiredNumberScheduled
+	// OVS is reconciled successfully
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // OVSExternalIDs is a set of configuration options for OVS external-ids table

--- a/controllers/ovs_controller.go
+++ b/controllers/ovs_controller.go
@@ -147,6 +147,7 @@ func (r *OVSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 		cl := condition.CreateList(
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
 			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
 			condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
 			condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),

--- a/controllers/ovs_controller.go
+++ b/controllers/ovs_controller.go
@@ -145,8 +145,6 @@ func (r *OVSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 		instance.Status.Conditions = condition.Conditions{}
 		// initialize conditions used later as Status=Unknown
 		cl := condition.CreateList(
-			condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
-			condition.UnknownCondition(condition.ExposeServiceReadyCondition, condition.InitReason, condition.ExposeServiceReadyInitMessage),
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),

--- a/controllers/ovs_controller.go
+++ b/controllers/ovs_controller.go
@@ -121,11 +121,18 @@ func (r *OVSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err
@@ -420,13 +427,13 @@ func (r *OVSReconciler) reconcileNormal(ctx context.Context, instance *ovsv1beta
 		return ctrl.Result{}, err
 	}
 
-	if instance.IsReady() {
+	if instance.Status.NumberReady == instance.Status.DesiredNumberScheduled {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 	}
 	// create DaemonSet - end
 
 	// create OVN Config Job - start
-	if instance.IsReady() {
+	if instance.Status.NumberReady == instance.Status.DesiredNumberScheduled {
 		jobsDef, err := ovs.ConfigJob(ctx, helper, r.Client, instance, serviceLabels)
 		if err != nil {
 			r.Log.Error(err, "Failed to create OVN controller configuration Job")


### PR DESCRIPTION
This ensures the Ready Condition is reset when CR becomes once ready but something fails during reconfiguration.

This also fixes a few conditions unused or not initialized.